### PR TITLE
:1234: cast threshold to number

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -16,7 +16,7 @@ module.exports = {
   POMI_RECORDS_FILE: 'records.json',
   INPUT_DIR: './input',
   // percentage the records can drop by before erroring
-  THRESHOLD: process.env.CHANGE_THRESHOLD || 0.99,
+  THRESHOLD: Number(process.env.CHANGE_THRESHOLD) || 0.99,
   // cron style job, default to 7:15am
   UPDATE_SCHEDULE: process.env.UPDATE_SCHEDULE || '15 7 * * *',
 };


### PR DESCRIPTION
Numeric values held in the vault are converted to a string when mapped through to Rancher.
This change ensures the CHANGE_THRESHOLD is a number within the application.